### PR TITLE
Simple webserver and `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the binary
+FROM golang:1.22.2 AS builder
+
+# Update ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Go project into the container
+COPY . .
+
+# Build the Go binary with static linking
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o summaraizer-slack-server cmd/summaraizer-slack/main.go
+
+# Stage 2: Create a minimal image with the compiled binary
+FROM scratch
+
+# Copy the CA certificates from the builder stage
+# Otherwise the Go code is unable to make HTTP requests
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Set environment variables for the application
+ENV PORT=8080
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/summaraizer-slack-server /summaraizer-slack-server
+
+# Set the entrypoint to the compiled binary
+ENTRYPOINT ["/summaraizer-slack-server"]
+
+# Pass runtime arguments to the binary
+CMD ["/summaraizer-slack-server", "--port", "${PORT}"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then you can simply deploy it with:
 vercel
 ```
 
-Be note that you have to set the environment variables in the Vercel dashboard (`Settings` -> `Environment Variables`).
+Note that you have to set the environment variables in the Vercel dashboard (`Settings` -> `Environment Variables`).
 After that, you have to **redeploy**. Otherwise, the env. variables changes won't take effect.
 
 #### Docker

--- a/README.md
+++ b/README.md
@@ -4,44 +4,131 @@
 
 ## What?
 
-Summaraizer summarizes your Slack thread discussions.
+summaraizer-slack summarizes your Slack thread discussions.
 
 ## How?
 
-There are a few steps required to add this integration to your Slack workspace:
+There are three steps to get this up and running:
+1. Set up the Slack integration
+2. Deploy the code to a server
+3. Invite the bot to your Slack channels (`/invite @BotName`)
+
+If this was successfully done, you can mention the bot in a thread 
+and ask it to summarize the thread with `@BotName summarize please`.
+
+### Slack Integration
 
 1. Go to `api.slack.com/apps`, and click on `Create New App`
 2. Go to `OAuth & Permissions` and add the following Scopes to the **Bot Token**:
-  * `app_mentions:read`
-  * `chat:write`
-  * `channels:history`
-  * `groups:history`
-  * `mpim:history`
-  * `im:history`
+   * `app_mentions:read`
+   * `chat:write`
+   * `channels:history`
+   * `groups:history`
+   * `mpim:history`
+   * `im:history`
 3. Click on "Install to Workspace"
 4. Accept everything (or wait until your Slack Admin approved it)
-5. Deploy this web app to `vercel` by running `vercel`
-6. Copy the (stable) deployment URL and go back to the Slack integration and click `Event subscriptions`
-7. Enable it and paste the vercel URL in it (for validation a small `Verifired ✅` should appear above it)
+5. [Deploy the code to a server](#deployment)
+6. Use the deployment URL, go back to the Slack integration and click `Event subscriptions`
+7. Enable it and paste the deployment URL in it (for validation a small `Verifired ✅` should appear above it)
 8. In the section `Subscribe to bot events`, enable `app_mention`
 9. Reinstall the Slack Bot to your workspace
-10. Go back to your `vercel` deployment -> settings and set the following secrets:
-  * `SLACK_BOT_TOKEN` (can be found in the Slack integration `OAuth & Permissions`)
-  * `OPENAI_API_TOKEN`
-11. Redeploy the version instance (to add the new secrets to that deployment)
 
-After this is done, you are able to invite your bot in your channels, group messages, etc.
-by typing `/invite @BotName`.
+### Deployment
 
-Finally, you can summaraize your threads by typing `@BotName summarize please`.
+Before deploying the code, you have follow the steps 1-4 from the [Slack Integration](#slack-integration) section.
+After you deployed the code, you can continue with the steps 6-9 steps.
+
+The following sections shows how to deploy the code to Vercel, as a Docker Image or on a Webserver.
+
+However, all options requires the `SLACK_BOT_TOKEN` environment variable to be set.
+Depending on which AI provider you want to use, 
+you have to set the `OPENAI_API_TOKEN` **or** `OLLAMA_URL` environment variable as well.
+
+The `SLACK_BOT_TOKEN` can be found in the Slack integration `OAuth & Permissions`.
+
+#### Vercel
+
+To deploy the code to Vercel, you need to have the Vercel CLI installed.
+Then you can simply deploy it with:
+
+```bash
+vercel
+```
+
+Be note that you have to set the environment variables in the Vercel dashboard (`Settings` -> `Environment Variables`).
+After that, you have to **redeploy**. Otherwise, the env. variables changes won't take effect.
+
+#### Docker
+
+To build the Docker image, you can run the following command:
+
+```bash  
+docker build -t summaraizer-slack .
+```
+
+To run that Docker image, you can use the following command:
+
+```bash
+docker run -p 8080:8080 -e SLACK_BOT_TOKEN=your-token -e OPENAI_API_TOKEN=your-token summaraizer-slack
+```
+
+
+#### Webserver
+
+To run the code on a webserver, you need to have Go installed.
+Then you can simply run the following command:
+
+```bash
+go run cmd/summaraizer-slack/main.go
+```
+
+Optional, you can specify the port with the `--port` flag.
+
+```bash
+go run cmd/summaraizer-slack/main.go --port 1234
+```
 
 ## Why?
 
-Ever run into a situation to got a bit overhelmed with the amound of comments
+Ever run into a situation where you got a bit overwhelmed with the amount of comments
 inside a Slack thread?
-Or you just came back from a nice 3 weeks vacation trip and now has to read
-a 75 comments long thread?
+Or you just came back from a nice 3-week vacation trip and now have to read
+a 75-comment long thread?
 
-Such problems are from the past now!
-Just run the summaraizer over it to get a summarization of all comments
-to get on track faster than ever before!
+Such problems are a thing of the past now!
+Just run the summaraizer over it to get a summary of all comments
+and get back on track faster than ever before!
+
+## Testing
+
+When you run the server locally, you need first to verify the domain with Slack.
+For this you can use `ngrok` or [`bore`](https://github.com/ekzhang/bore) to create a tunnel to your local server.
+
+Both will give you a free URL that you can paste into the Slack integration.
+Once confirmed, you can disable the tunnel again.
+
+### Docker
+
+When you want to run the Docker image together with a local Ollama instance, you can use the following command:
+
+```bash
+docker run -p 8080:8080 -e SLACK_BOT_TOKEN=your-token -e OLLAMA_URL=http://host.docker.internal:11434 summaraizer-slack
+```
+
+### Fake Slack Event
+
+To fake a Slack event, you can use the following `curl` command:
+
+```bash
+curl -X POST http://localhost:8080 -H "Content-Type: application/json" -d '{
+  "type": "event_callback",
+  "event": {
+    "type": "app_mention",
+    "user": "U123456",
+    "text": "Please summarize this",
+    "thread_ts": "[Thread Timestamp]", 
+    "channel": "[Channel ID]",
+  }
+}'
+```

--- a/api/healthz.go
+++ b/api/healthz.go
@@ -1,0 +1,8 @@
+package api
+
+import "net/http"
+
+func HealthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/api/index.go
+++ b/api/index.go
@@ -28,7 +28,7 @@ var slackBotToken = os.Getenv("SLACK_BOT_TOKEN")
 var openAiToken = os.Getenv("OPENAI_API_TOKEN")
 var ollamUrl = os.Getenv("OLLAMA_URL")
 
-func Handler(w http.ResponseWriter, r *http.Request) {
+func IndexHandler(w http.ResponseWriter, r *http.Request) {
 	if slackBotToken == "" {
 		http.Error(w, "SLACK_BOT_TOKEN is not set", http.StatusInternalServerError)
 		return

--- a/api/ready.go
+++ b/api/ready.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+)
+
+func ReadyHandler(w http.ResponseWriter, r *http.Request) {
+	validSlackToken := checkSlackBotToken()
+	if !validSlackToken {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Invalid Slack Bot Token"))
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
+func checkSlackBotToken() bool {
+	slackBotToken := os.Getenv("SLACK_BOT_TOKEN")
+	if slackBotToken == "" {
+		return false
+	}
+
+	req, err := http.NewRequest("POST", "https://slack.com/api/auth.test", nil)
+	if err != nil {
+		return false
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+slackBotToken)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	var response map[string]interface{}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return false
+	}
+
+	return response["ok"].(bool)
+}

--- a/cmd/summaraizer-slack/main.go
+++ b/cmd/summaraizer-slack/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/ioki-mobility/summaraizer-slack/api"
+)
+
+func main() {
+	http.HandleFunc("/", api.Handler)
+
+	port := parsePort()
+	address := fmt.Sprintf(":%s", port)
+	if err := http.ListenAndServe(address, nil); err != nil {
+		fmt.Printf("Failed to start server: %v\n", err)
+	}
+}
+
+func parsePort() string {
+	port := flag.String("port", "8080", "Port to listen on. Default is 8080")
+	flag.Parse()
+
+	return *port
+}

--- a/cmd/summaraizer-slack/main.go
+++ b/cmd/summaraizer-slack/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	http.HandleFunc("/", api.IndexHandler)
 	http.HandleFunc("/healthz", api.HealthzHandler)
+	http.HandleFunc("/ready", api.ReadyHandler)
 
 	port := parsePort()
 	address := fmt.Sprintf(":%s", port)

--- a/cmd/summaraizer-slack/main.go
+++ b/cmd/summaraizer-slack/main.go
@@ -9,7 +9,8 @@ import (
 )
 
 func main() {
-	http.HandleFunc("/", api.Handler)
+	http.HandleFunc("/", api.IndexHandler)
+	http.HandleFunc("/healthz", api.HealthzHandler)
 
 	port := parsePort()
 	address := fmt.Sprintf(":%s", port)


### PR DESCRIPTION
fixes #5 
contributes to #6 

This introduces a simple webserver in `cmd/summaraizer-slack`.
It simply uses the stuff in `api/` so it is still compatible with Vercel 🎉 

I also added a `Dockerfile` so it can run in a container.
I haven't created an GItHub Action yet to deploy the image to the GitHub Container Registry.
This will happen in a follow-up ticket.

However, the Docker Image is already available here:
https://github.com/orgs/ioki-mobility/packages/container/package/summaraizer-slack
(not visible yet for non-members)

I also update the README with a lot of information how to run that and a few nice testing hacks 🚀 