### PR TITLE
Fix thinking message

### DIFF
--- a/api/event.go
+++ b/api/event.go
@@ -61,10 +61,9 @@ func EventHandler(w http.ResponseWriter, r *http.Request) {
 		threadTs, _ := innerEvent["thread_ts"].(string)
 		channel, _ := innerEvent["channel"].(string)
 
-		messageTs := slack.SendMessage(":brain: Thinking...", channel, threadTs, slackBotToken)
-
 		if threadTs != "" && strings.Contains(strings.ToLower(text), "summarize") {
 			log.Printf("Summarize request in channel %s, thread %s by %s", channel, threadTs, user)
+			messageTs := slack.SendMessage(":brain: Thinking...", channel, threadTs, slackBotToken)
 			summarization := fetchAndSummarize(channel, threadTs)
 			slack.UpdateMessage(messageTemplate(summarization), channel, messageTs, slackBotToken)
 		}


### PR DESCRIPTION
Thinking should only be posted when it got requested to think 🙃 
Right now it always sends "Thinking" when mentioned...
![Screenshot 2025-01-06 at 10 26 48 AM](https://github.com/user-attachments/assets/d4972e2a-571a-4af4-8071-e5a1ea44e976)


This fixes it